### PR TITLE
fix reverse proxy

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -3,7 +3,11 @@ server {
     listen 80;
     server_name localhost;
 
-    location ^~ /jenkins/ {
+    location / {    
+        if ($request_uri ~* "/jenkins(/.*)") {
+            proxy_pass http://jenkins:8080/jenkins$1;
+            break;
+        }
 
         proxy_set_header        Host $host:$server_port;
         proxy_set_header        X-Real-IP $remote_addr;


### PR DESCRIPTION
Refers to https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-nginx/
We have to add this snippet 
![Screenshot from 2021-02-23 13-21-07](https://user-images.githubusercontent.com/10054261/108808846-23ddf080-75da-11eb-8e22-58aa425f4918.png)
to our nginx configuration to solve _**It appears that your reverse proxy setup is broken**_ problem.